### PR TITLE
Changed how BuildMaster release number is matched to TFS work items for issues list

### DIFF
--- a/Tfs2012Issue.cs
+++ b/Tfs2012Issue.cs
@@ -22,7 +22,7 @@ namespace Inedo.BuildMasterExtensions.TFS2012
         private static string GetReleaseNumber(WorkItem workItem, string customReleaseNumberFieldName)
         {
             if (string.IsNullOrEmpty(customReleaseNumberFieldName))
-                return workItem.IterationPath.Substring(workItem.IterationPath.LastIndexOf('\\') + 1);
+                return workItem.IterationPath + @"\"; // Add a backslash to the end of the iteration path in case our release number shows up at the end.
             else
                 return workItem.Fields[customReleaseNumberFieldName].Value.ToString().Trim();
         }

--- a/Tfs2012Issue.cs
+++ b/Tfs2012Issue.cs
@@ -24,7 +24,7 @@ namespace Inedo.BuildMasterExtensions.TFS2012
             if (string.IsNullOrEmpty(customReleaseNumberFieldName))
                 return workItem.IterationPath + @"\"; // Add a backslash to the end of the iteration path in case our release number shows up at the end.
             else
-                return workItem.Fields[customReleaseNumberFieldName].Value.ToString().Trim();
+                return @"\" + workItem.Fields[customReleaseNumberFieldName].Value.ToString().Trim() + @"\";
         }
     }
 }

--- a/Tfs2012IssueTrackingProvider.cs
+++ b/Tfs2012IssueTrackingProvider.cs
@@ -144,7 +144,7 @@ namespace Inedo.BuildMasterExtensions.TFS2012
                 return workItems
                     .Cast<WorkItem>()
                     .Select(wi => new Tfs2010Issue(wi, this.CustomReleaseNumberFieldName))
-                    .Where(wi => wi.ReleaseNumber == releaseNumber)
+                    .Where(wi => wi.ReleaseNumber.Contains(@"\" + releaseNumber)) // Add backslash to the beginning so we don't match on things like 1.0.0 and 11.0.0.
                     .ToArray();
             }
         }


### PR DESCRIPTION
Previously, the whole iteration path had to match the BuildMaster release number; now, if the release number appears anywhere in the iteration path for that work item, it will be included in the issues list for that release. The normal rules for filtering on area path and project still apply, so if the area path doesn't match, the work item will never be included regardless of what the iteration path is. This is useful for people who have nested TFS iteration paths with the release at an arbitrary level in the hierarchy, e.g. Project\Area1\1.0.0\Iteration 2.
